### PR TITLE
Fix tilde paths in compose files

### DIFF
--- a/overleaf/docker-compose.yml
+++ b/overleaf/docker-compose.yml
@@ -88,7 +88,7 @@ services:
         expose:
             - 27017
         volumes:
-            - ~/mongo_data:/data/db
+            - $HOME/mongo_data:/data/db
         healthcheck:
             test: echo 'db.stats().ok' | mongo localhost:27017/test --quiet
             interval: 10s
@@ -102,7 +102,7 @@ services:
         expose:
             - 6379
         volumes:
-            - ~/redis_data:/data
+            - $HOME/redis_data:/data
 
     # ldap:
     #    restart: always

--- a/photoprism/docker-compose.yml
+++ b/photoprism/docker-compose.yml
@@ -4,7 +4,7 @@ services:
     image: photoprism/photoprism:latest
     restart: unless-stopped
     container_name: photoprism
-        # user: "1000:1000"
+    # user: "1000:1000"
     security_opt:
       - seccomp:unconfined
       - apparmor:unconfined
@@ -56,14 +56,14 @@ services:
       # UMASK: 0000
     volumes:
       # Storage folder for settings, index & sidecar files (DON'T REMOVE):
-      - "~/.photoprism:/photoprism/storage"
+      - "$HOME/.photoprism:/photoprism/storage"
       # Your personal photo and video collection ([local path]:[container path]):
-      - "~/Pictures:/photoprism/originals"
+      - "$HOME/Pictures:/photoprism/originals"
       # Multiple folders can be indexed by mounting them as subfolders of /photoprism/originals:
-      # - "~/Family:/photoprism/originals/Family"    # [folder_1]:/photoprism/originals/[folder_1]
-      # - "~/Friends:/photoprism/originals/Friends"  # [folder_2]:/photoprism/originals/[folder_2]
+      # - "$HOME/Family:/photoprism/originals/Family"    # [folder_1]:/photoprism/originals/[folder_1]
+      # - "$HOME/Friends:/photoprism/originals/Friends"  # [folder_2]:/photoprism/originals/[folder_2]
       # Mounting the import folder is optional (see docs):
-      # - "~/Import:/photoprism/import"
+      # - "$HOME/Import:/photoprism/import"
     # Uncomment the following lines to use MariaDB instead of SQLite for improved performance & scalability:
     #
     #  mariadb:


### PR DESCRIPTION
## Summary
- fix unresolved tilde paths in `overleaf` and `photoprism` compose files
- standardize indentation in `photoprism` compose

## Testing
- `yamllint overleaf/docker-compose.yml photoprism/docker-compose.yml`


------
https://chatgpt.com/codex/tasks/task_e_68710ff19780832c9450e66c83a2518d